### PR TITLE
Trap shell errors from backup and backup_globals methods

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -314,8 +314,10 @@ sub backup {
                   defined $args{format} ? "-F$args{format} "            : '' ,
                   $self->dbname         ? $self->_dbname_q   : '' ,
                   qq(> "$tempfile" )));
-    my $stderr = capture_stderr { local ($?, $!);
-                                  `$command` };
+    my $stderr = capture_stderr {
+        local ($?, $!);
+        system $command and die $!;
+    };
     print STDERR $stderr;
     for my $err (split /\n/, $stderr) {
           die $err if $err =~ /(ERROR|FATAL)/;

--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -364,8 +364,10 @@ sub backup_globals {
                   $self->host           ? "-h " . $self->host . " "     : '' ,
                   $self->port           ? "-p " . $self->port . " "     : '' ,
                   qq(> "$tempfile" )));
-    my $stderr = capture_stderr { local ($?, $!);
-                                  `$command` };
+    my $stderr = capture_stderr {
+        local ($?, $!);
+        system $command and die $!
+    };
     print STDERR $stderr;
     for my $err (split /\n/, $stderr) {
           die $err if $err =~ /(ERROR|FATAL)/;

--- a/t/03-shellexceptions.t
+++ b/t/03-shellexceptions.t
@@ -2,7 +2,7 @@ use Test::More;
 use PGObject::Util::DBAdmin;
 use Test::Exception;
 
-plan tests => 4;
+plan tests => 7;
 
 # These tests do not require a working database connection
 my $db = PGObject::Util::DBAdmin->new(
@@ -35,3 +35,26 @@ dies_ok {
         tempdir => 't/data/an_existing_file'
     )
 } 'backup db tempdir is an existing file';
+
+
+dies_ok {
+    $db->backup_globals(
+        tempdir => 'This_directory_does_not_exist'
+    )
+} 'backup_globals with non-existent tempdir';
+
+dies_ok {
+    $db->backup_globals(
+        file => 't/data/an_existing_file/cannot_write'
+    )
+} 'backup_globals cannot write to specified file';
+
+dies_ok {
+    $db->backup_globals(
+        tempdir => 't/data/an_existing_file'
+    )
+} 'backup_globals tempdir is an existing file';
+
+
+
+

--- a/t/03-shellexceptions.t
+++ b/t/03-shellexceptions.t
@@ -2,7 +2,7 @@ use Test::More;
 use PGObject::Util::DBAdmin;
 use Test::Exception;
 
-plan tests => 2;
+plan tests => 4;
 
 # These tests do not require a working database connection
 my $db = PGObject::Util::DBAdmin->new(
@@ -23,3 +23,15 @@ dies_ok {
         format => 'THIS_IS_A_BAD_FORMAT'
     )
 } 'backup db with bad format';
+
+dies_ok {
+    $db->backup(
+        file => 't/data/an_existing_file'
+    )
+} 'backup db would overwrite an existing file';
+
+dies_ok {
+    $db->backup(
+        tempdir => 't/data/an_existing_file'
+    )
+} 'backup db tempdir is an existing file';

--- a/t/03-shellexceptions.t
+++ b/t/03-shellexceptions.t
@@ -26,9 +26,9 @@ dies_ok {
 
 dies_ok {
     $db->backup(
-        file => 't/data/an_existing_file'
+        file => 't/data/an_existing_file/cannot_write'
     )
-} 'backup db would overwrite an existing file';
+} 'backup db cannot write to specified file';
 
 dies_ok {
     $db->backup(

--- a/t/03-shellexceptions.t
+++ b/t/03-shellexceptions.t
@@ -1,0 +1,25 @@
+use Test::More;
+use PGObject::Util::DBAdmin;
+use Test::Exception;
+
+plan tests => 2;
+
+# These tests do not require a working database connection
+my $db = PGObject::Util::DBAdmin->new(
+   username => 'postgres'        ,
+   host     => 'localhost'       ,
+   port     => '5432'            ,
+   dbname   => 'pgobject_test_db',
+);
+
+dies_ok {
+    $db->backup(
+        tempdir => 'This_directory_does_not_exist'
+    )
+} 'backup db with non-existent tempdir';
+
+dies_ok {
+    $db->backup(
+        format => 'THIS_IS_A_BAD_FORMAT'
+    )
+} 'backup db with bad format';


### PR DESCRIPTION
Previously shell errors in the system calls made by backup and backup_globals methods would not be trapped - instead the methods returned success. This caused silent backup failures in projects that use this code, such as ledgersmb.