### PR TITLE
Remove documentation for unimplemented continue_on_error argument

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -219,12 +219,7 @@ Path to error log to store stderr output
 
 =item stdout_log
 
-
 Path to where to log standard output
-
-=item continue_on_error
-
-If set, does not die on error.
 
 =back
 


### PR DESCRIPTION
Remove documentation for unimplemented continue_on_error argument in `run_file` method.