### PR TITLE
Trap more errors

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -267,8 +267,8 @@ sub run_file {
     };
 
     print STDERR $stderr;
-    print ERRLOG $stderr if $errlog;
     if($errlog) {
+        print ERRLOG $stderr;
         close ERRLOG or croak "Failed to close log file after writing $!";
     }
     for my $err (split /\n/, $stderr) {
@@ -454,8 +454,8 @@ sub restore {
         system $command and die "error running pg_restore command $!";
     };
     print STDERR $stderr;
-    print ERRLOG $stderr if $errlog;
     if($errlog) {
+        print ERRLOG $stderr;
         close ERRLOG or croak "Failed to close log file after writing $!";
     }
     for my $err (split /\n/, $stderr) {

--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -239,6 +239,7 @@ sub run_file {
        $log = qq( 1>&2 );
        $errlog = 1;
        open(ERRLOG, '>>', $args{log})
+           or croak "Cannot open specified log file for writing $!";
     } else {
        if ($args{stdout_log}){
           $log .= qq(>> "$args{stdout_log}" );
@@ -246,6 +247,7 @@ sub run_file {
        if ($args{errlog}){
           $errlog = 1;
           open(ERRLOG, '>>', $args{errlog})
+           or croak "Cannot open specified errlog file for writing $!";
        }
     }
     my $command = qq(psql -f "$args{file}" )
@@ -266,7 +268,8 @@ sub run_file {
 
     print STDERR $stderr;
     print ERRLOG $stderr if $errlog;
-    close ERRLOG if $errlog;
+    close ERRLOG if $errlog
+        or croak "Failed to close log file after writing $!";
     for my $err (split /\n/, $stderr) {
           die $err if $err =~ /(ERROR|FATAL)/;
     }

--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -192,8 +192,10 @@ sub create {
                        $self->port     ? "-p " . $self->port . " "     : '' ,
                        $self->dbname   ? $self->_dbname_q              : '' )
                   );
-    my $stderr = capture_stderr sub{ local ($?, $!);
-                                     `$command` };
+    my $stderr = capture_stderr {
+        local ($?, $!);
+        system $command and croak "error running createdb command $!";
+    };
     die $stderr if $stderr;
     return 1;
 }

--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -268,8 +268,9 @@ sub run_file {
 
     print STDERR $stderr;
     print ERRLOG $stderr if $errlog;
-    close ERRLOG if $errlog
-        or croak "Failed to close log file after writing $!";
+    if($errlog) {
+        close ERRLOG or croak "Failed to close log file after writing $!";
+    }
     for my $err (split /\n/, $stderr) {
           die $err if $err =~ /(ERROR|FATAL)/;
     }
@@ -454,8 +455,9 @@ sub restore {
     };
     print STDERR $stderr;
     print ERRLOG $stderr if $errlog;
-    close ERRLOG if $errlog
-        or croak "Failed to close log file after writing $!";
+    if($errlog) {
+        close ERRLOG or croak "Failed to close log file after writing $!";
+    }
     for my $err (split /\n/, $stderr) {
           die $err if $err =~ /(ERROR|FATAL)/;
     }

--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -470,8 +470,10 @@ sub drop {
                   $self->host     ? "-h " . $self->host . " "     : '' ,
                   $self->port     ? "-p " . $self->port . " "     : '' ,
                   $self->_dbname_q));
-    my $stderr = capture_stderr { local ($?, $!);
-                                  `$command` };
+    my $stderr = capture_stderr {
+        local ($?, $!);
+        system $command and die;
+    };
     die $stderr if $stderr =~ /(ERROR|FATAL)/;
     return 1;
 }

--- a/t/03-shellexceptions.t
+++ b/t/03-shellexceptions.t
@@ -2,7 +2,7 @@ use Test::More;
 use PGObject::Util::DBAdmin;
 use Test::Exception;
 
-plan tests => 10;
+plan tests => 12;
 
 # These tests do not require a working database connection
 my $db = PGObject::Util::DBAdmin->new(
@@ -55,6 +55,7 @@ dies_ok {
     )
 } 'backup_globals tempdir is an existing file';
 
+
 throws_ok {
     $db->restore(
         file   => 't/data/an_existing_file',
@@ -81,5 +82,19 @@ dies_ok {
 } 'restore method called with invalid format';
 
 
+throws_ok {
+    $db->run_file(
+        file   => 't/data/an_existing_file',
+        log    => 't/data/an_existing_file/cannot_write',
+    )
+} qr/^Cannot open specified log file for writing/,
+'run_file log file is unwriteable';
 
+throws_ok {
+    $db->run_file(
+        file   => 't/data/an_existing_file',
+        errlog => 't/data/an_existing_file/cannot_write',
+    )
+} qr/^Cannot open specified errlog file for writing/,
+'run_file errlog file is unwriteable';
 

--- a/t/03-shellexceptions.t
+++ b/t/03-shellexceptions.t
@@ -2,7 +2,7 @@ use Test::More;
 use PGObject::Util::DBAdmin;
 use Test::Exception;
 
-plan tests => 7;
+plan tests => 10;
 
 # These tests do not require a working database connection
 my $db = PGObject::Util::DBAdmin->new(
@@ -54,6 +54,31 @@ dies_ok {
         tempdir => 't/data/an_existing_file'
     )
 } 'backup_globals tempdir is an existing file';
+
+throws_ok {
+    $db->restore(
+        file   => 't/data/an_existing_file',
+        log    => 't/data/an_existing_file/cannot_write',
+        format => 'c',
+    )
+} qr/^Cannot open specified log file for writing/,
+'restore log file is unwriteable';
+
+throws_ok {
+    $db->restore(
+        file   => 't/data/an_existing_file',
+        errlog => 't/data/an_existing_file/cannot_write',
+        format => 'c',
+    )
+} qr/^Cannot open specified errlog file for writing/,
+'restore errlog file is unwriteable';
+
+dies_ok {
+    $db->restore(
+        file   => 't/data/an_existing_file',
+        format => 'AN_INVALID_FORMAT',
+    )
+} 'restore method called with invalid format';
 
 
 


### PR DESCRIPTION
Raise an error if system calls fail, rather than carrying on to return success. Error checking added to file operations and system commands.