### PR TITLE
Safer system calls, output captured to object property not file

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -83,9 +83,48 @@ has port => (is => 'ro');
 
 has dbname => (is => 'ro');
 
+=head2 stderr
+
+When applicable, the stderr output captured from any external commands (for
+example createdb or pg_restore) run during the previous method call.
+
+=cut
+
+has stderr => (is => 'ro');
+
+=head2 stdout
+
+When applicable, the stdout output captured from any external commands (for
+example createdb or pg_restore) run during the previous method call.
+
+=cut
+
+has stdout => (is => 'ro');
+
+
 sub _dbname_q {
     my ($self) = @_;
     return "'" . $self->dbname . "'";
+}
+
+
+sub _run_command {
+    my ($self, @command) = @_;
+
+    my $exit_code;
+    ($self->{stdout}, $self->{stderr}, $exit_code) = capture {
+        system @command;
+    };
+
+    if($exit_code != 0) {
+        croak "error running command";
+    }
+
+    for my $err (split /\n/, $self->{stderr}) {
+        croak $err if $err =~ /(ERROR|FATAL)/;
+    }
+
+    return 1;
 }
 
 
@@ -200,30 +239,24 @@ sub create {
     return 1;
 }
 
+
 =head2 run_file
 
-Run the specified file on the db.  Accepted parameters are:
+Run the specified file on the db.
+
+After calling this method, STDOUT and STDERR output from the external
+utility which runs the file on the database are available as properties
+$db->stdout and $db->stderr respectively.
+
+Croaks on error. Returns true on success.
+
+Recognized arguments are:
 
 =over
 
 =item file
 
-Path to file to be run.
-
-=item log
-
-Optional path to combined stderr/stdout log.  If specified, do not specify other
-logs as this is unsupported.
-
-=item errlog
-
-Optional path to error log to store stderr output. Ignored if log parameter
-is set.
-
-=item stdout_log
-
-Optional path to where to log standard output. Ignored if log parameter is
-set.
+Path to file to be run. This is a mandatory argument.
 
 =back
 
@@ -231,51 +264,24 @@ set.
 
 sub run_file {
     my ($self, %args) = @_;
-    croak 'Must specify file' unless $args{file};
-    local $ENV{PGPASSWORD} = $self->password if $self->password;
-    my $log = '';
-    my $errlog = 0;
-    if ($args{log}){
-       $log = qq( 1>&2 );
-       $errlog = 1;
-       open(ERRLOG, '>>', $args{log})
-           or croak "Cannot open specified log file for writing $!";
-    } else {
-       if ($args{stdout_log}){
-          $log .= qq(>> "$args{stdout_log}" );
-       }
-       if ($args{errlog}){
-          $errlog = 1;
-          open(ERRLOG, '>>', $args{errlog})
-           or croak "Cannot open specified errlog file for writing $!";
-       }
-    }
-    my $command = qq(psql -f "$args{file}" )
-                  . join(' ',
-                       ($self->username ? "-U " . $self->username . ' ' : '',
-                        $self->host     ? "-h " . $self->host . " "     : '' ,
-                        $self->port     ? "-p " . $self->port . " "     : '' ,
-                        $self->dbname ? $self->_dbname_q : ' ' ,
-                        $log)
-                  );
-    my $stderr = capture_stderr sub {
-        local ($?, $!);
-        my $result = `$command`;
-        print STDERR "\nAPPLICATION ERROR\n"
-            if $? != 0;
-        return $result;
-    };
+    $self->{stderr} = undef;
+    $self->{stdout} = undef;
 
-    print STDERR $stderr;
-    if($errlog) {
-        print ERRLOG $stderr;
-        close ERRLOG or croak "Failed to close log file after writing $!";
-    }
-    for my $err (split /\n/, $stderr) {
-          die $err if $err =~ /(ERROR|FATAL)/;
-    }
-    return 1;
+    croak 'Must specify file' unless defined $args{file};
+    croak 'Specified file does not exist' unless -e $args{file};
+
+    local $ENV{PGPASSWORD} = $self->password if defined $self->password;
+
+    # Build command
+    my @command = ('psql', '-f', $args{file});
+    $self->username and push(@command, "-U", $self->username);
+    $self->host     and push(@command, "-h", $self->host);
+    $self->port     and push(@command, "-p", $self->port);
+    $self->dbname   and push(@command, $self->dbname);
+
+    return $self->_run_command(@command);
 }
+
 
 =head2 backup
 
@@ -382,9 +388,16 @@ sub backup_globals {
     return $tempfile;
 }
 
+
 =head2 restore
 
 Restores from a saved file.  Must pass in the file name as a named argument.
+
+After calling this method, STDOUT and STDERR output from the external
+restore utility are available as properties $db->stdout and $db->stderr
+respectively.
+
+Croaks on error. Returns true on success.
 
 Recognized arguments are:
 
@@ -392,26 +405,11 @@ Recognized arguments are:
 
 =item file
 
-Path to file
+Path to file which will be restored to the database.
 
 =item format
 
-The specified format, for example c for custom.  Defaults to plain text
-
-=item log
-
-Optional path to combined stderr/stdout log.  If specified, do not specify other logs
-as this is unsupported.
-
-=item errlog
-
-Optional path to error log to store stderr output. Ignored if log parameter
-is set.
-
-=item stdout_log
-
-Optional path to where to log standard output. Ignored if log parameter is
-set.
+The file format, for example c for custom.  Defaults to plain text.
 
 =back
 
@@ -419,50 +417,29 @@ set.
 
 sub restore {
     my ($self, %args) = @_;
-    croak 'Must specify file' unless $args{file};
+    $self->{stderr} = undef;
+    $self->{stdout} = undef;
+
+    croak 'Must specify file' unless defined $args{file};
+    croak 'Specified file does not exist' unless -e $args{file};
 
     return $self->run_file(%args)
            if not defined $args{format} or $args{format} eq 'p';
 
-    local $ENV{PGPASSWORD} = $self->password if $self->password;
-    my $log = '';
-    my $errlog;
-    if ($args{log}){
-       $log = qq( 1>&2 );
-       $errlog = 1;
-       open(ERRLOG, '>>', $args{log})
-           or croak "Cannot open specified log file for writing $!";
-    } else {
-       if ($args{stdout_log}){
-          $log .= qq(>> "$args{stdout_log}" );
-       }
-       if ($args{errlog}){
-          $errlog = 1;
-          open(ERRLOG, '>>', $args{errlog})
-              or croak "Cannot open specified errlog file for writing $!";
-       }
-    }
-    my $command = 'pg_restore ' . join(' ', (
-                  $self->dbname         ? "-d " . $self->_dbname_q . " "   : '' ,
-                  $self->username       ? "-U " . $self->username . ' ' : '' ,
-                  $self->host           ? "-h " . $self->host . " "     : '' ,
-                  $self->port           ? "-p " . $self->port . " "     : '' ,
-                  defined $args{format} ? "-F$args{format}"             : '' ,
-                  qq("$args{file}")));
-    my $stderr = capture_stderr sub {
-        local ($?, $!);
-        system $command and die "error running pg_restore command $!";
-    };
-    print STDERR $stderr;
-    if($errlog) {
-        print ERRLOG $stderr;
-        close ERRLOG or croak "Failed to close log file after writing $!";
-    }
-    for my $err (split /\n/, $stderr) {
-          die $err if $err =~ /(ERROR|FATAL)/;
-    }
-    return 1;
+    local $ENV{PGPASSWORD} = $self->password if defined $self->password;
+
+    # Build command options
+    my @command = ('pg_restore', '--verbose');
+    $self->dbname   and push(@command, "-d", $self->dbname);
+    $self->username and push(@command, "-U", $self->username);
+    $self->host     and push(@command, "-h", $self->host);
+    $self->port     and push(@command, "-p", $self->port);
+    defined $args{format} and push(@command, "-F$args{format}");
+    push(@command, $args{file});
+
+    return $self->_run_command(@command);
 }
+
 
 =head2 drop
 

--- a/t/01-dbtests.t
+++ b/t/01-dbtests.t
@@ -1,8 +1,9 @@
 use Test::More;
+use Test::Exception;
 use PGObject::Util::DBAdmin;
 
 plan skip_all => 'DB_TESTING not set' unless $ENV{DB_TESTING};
-plan tests => 33;
+plan tests => 50;
 
 # Constructor
 
@@ -21,7 +22,11 @@ ok($db = PGObject::Util::DBAdmin->new(
 
 eval { $db->drop };
 
-ok($db->backup_globals, 'can backup globals');
+my $backup_file;
+ok($backup_file = $db->backup_globals, 'can backup globals');
+ok(-f $backup_file, 'backup_globals output file exists');
+cmp_ok(-s $backup_file, '>', 0, 'backup_globals output file has size > 0');
+unlink $backup_file;
 
 # List dbs
 my @dblist;
@@ -50,27 +55,39 @@ is ($foo->[0], 1, 'Correct count of data') ;
 $dbh->disconnect;
 
 # backup/drop/create/restore, formats undef, p, and c
+foreach my $format ((undef, 'p', 'c')) {
+    my $display_format = $format || 'undef';
 
-no warnings;
-for ((undef, 'p', 'c')) {
     my $backup;
     ok($backup = $db->backup(
-           format => $_,
+           format => $format,
            tempdir => 't/var/',
-       ), 'Made backup, format ' . $_ || 'undef');
-    ok($db->drop, 'dropped db, format ' . $_ || 'undef');
+       ), "Made backup, format $display_format");
+    ok(-f $backup, "backup format $display_format output file exists");
+    cmp_ok(-s $backup, '>', 0, "backup format $display_format output file has size > 0");
+
+    ok($db->drop, "dropped db, format $display_format");
     ok (!(grep{$_ eq 'pgobject_test_db'} @dblist), 
            'DB list does not contain pgobject_test_db');
 
-    ok($db->create, 'created db, format ' . $_ || 'undef');
-    ok($dbh = $db->connect, 'Got dbi handle ' . $_ || 'undef');
+    dies_ok {
+        $db->restore(
+            format => $format,
+            file   => 't/data/does-not-exist',
+        )
+    } "die when restore file does not exist, format $display_format";
+
+    ok($db->create, "created db, format $display_format");
+    ok($dbh = $db->connect, "Got dbi handle, format $display_format");
     ok($db->restore(
-          format => $_,
+          format => $format,
           file   => $backup,
-       ), 'Restored backup, format ' . $_ || 'undef');
+       ), "Restored backup, format $display_format");
+    ok(defined $db->stderr, 'stderr captured during restore');
+    ok(defined $db->stdout, 'stdout captured during restore');
     ok(($foo) = $dbh->selectall_arrayref('select count(*) from test_data'),
-               'Got results from test data count ' . $_ || 'undef');
-    is($foo->[0]->[0], 1, 'correct data count ' . $_ || 'undef');
+               "Got results from test data count, format $display_format");
+    is($foo->[0]->[0], 1, "correct data count, format $display_format");
     $dbh->disconnect;
     unlink $backup;
 }

--- a/t/03-shellexceptions.t
+++ b/t/03-shellexceptions.t
@@ -2,7 +2,7 @@ use Test::More;
 use PGObject::Util::DBAdmin;
 use Test::Exception;
 
-plan tests => 12;
+plan tests => 8;
 
 # These tests do not require a working database connection
 my $db = PGObject::Util::DBAdmin->new(
@@ -56,45 +56,9 @@ dies_ok {
 } 'backup_globals tempdir is an existing file';
 
 
-throws_ok {
-    $db->restore(
-        file   => 't/data/an_existing_file',
-        log    => 't/data/an_existing_file/cannot_write',
-        format => 'c',
-    )
-} qr/^Cannot open specified log file for writing/,
-'restore log file is unwriteable';
-
-throws_ok {
-    $db->restore(
-        file   => 't/data/an_existing_file',
-        errlog => 't/data/an_existing_file/cannot_write',
-        format => 'c',
-    )
-} qr/^Cannot open specified errlog file for writing/,
-'restore errlog file is unwriteable';
-
 dies_ok {
     $db->restore(
         file   => 't/data/an_existing_file',
         format => 'AN_INVALID_FORMAT',
     )
 } 'restore method called with invalid format';
-
-
-throws_ok {
-    $db->run_file(
-        file   => 't/data/an_existing_file',
-        log    => 't/data/an_existing_file/cannot_write',
-    )
-} qr/^Cannot open specified log file for writing/,
-'run_file log file is unwriteable';
-
-throws_ok {
-    $db->run_file(
-        file   => 't/data/an_existing_file',
-        errlog => 't/data/an_existing_file/cannot_write',
-    )
-} qr/^Cannot open specified errlog file for writing/,
-'run_file errlog file is unwriteable';
-


### PR DESCRIPTION
Following discussion (https://matrix.to/#/!qyoLumPqusaXqFJNyK:matrix.org/$15207803991446829DEbcY:matrix.org) This patch is the beginning of work to:

* Make `system` calls using list context, rather than as a single shell string. This saves having to escape shell characters and the problems when this isn't done correctly or comprehensively.
* Move away from using shell redirection to write log files of the stderr and stdout from external commands and instead capture this output and make it available as object properties.

This PR makes changes to the `run_file` and `restore` methods. Subject to feedback and any discussion, similar changes will next be made to the other methods.

Issue: Current behaviour is to `die` or `croak` on errors. This means that the stderr and stdout properties will not be available after an error, as the object they belong to will have been destroyed. Do we want to change behaviour to return false on error, rather than die-ing?