### PR TITLE
Delegate default temp dir to File::Temp

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -163,7 +163,6 @@ sub _open_temp_filehandle {
     my %file_options = (UNLINK => 0);
 
     if(defined $args{tempdir}) {
-        $args{tempdir} =~ s|/$||; # strip trailing slash if present
         -d $args{tempdir}
             or croak "directory $args{tempdir} does not exist or is not a directory";
         $file_options{DIR} = $args{tempdir};

--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -160,14 +160,17 @@ sub _open_temp_filehandle {
         return $fh;
     }
 
-    my $tempdir = $args{tempdir} // $ENV{TEMP} // '/tmp';
-    $tempdir =~ s|/$||;
-    -d $tempdir or croak "directory $tempdir does not exist or is not a directory";
+    my %file_options = (UNLINK => 0);
 
-    my $fh = File::Temp->new(
-        DIR => $tempdir,
-        UNLINK => 0
-    ) or die "could not create temp file: $@, $!";
+    if(defined $args{tempdir}) {
+        $args{tempdir} =~ s|/$||; # strip trailing slash if present
+        -d $args{tempdir}
+            or croak "directory $args{tempdir} does not exist or is not a directory";
+        $file_options{DIR} = $args{tempdir};
+    }
+
+    my $fh = File::Temp->new(%file_options)
+        or die "could not create temp file: $@, $!";
 
     return $fh;
 }
@@ -395,8 +398,8 @@ specified, a file will be created using File::Temp.
 
 =item tempdir
 
-The directory to store temp files in.  Defaults to $ENV{TEMP} if set and
-'/tmp' if not. Ignored if file paramter is given.
+The directory in which to write the backup file. Optional parameter.  Uses
+File::Temp default if not defined.  Ignored if file paramter is given.
 
 =back
 
@@ -448,8 +451,8 @@ specified, a file will be created using File::Temp.
 
 =item tempdir
 
-The directory to store temp files in.  Defaults to $ENV{TEMP} if set and
-'/tmp/' if not. Ignored if file paramter is given.
+The directory in which to write the backup file. Optional parameter.  Uses
+File::Temp default if not defined.  Ignored if file paramter is given.
 
 =back
 


### PR DESCRIPTION
Delegate default tempdir to File::Temp
   
No need for us to try to guess our own temporary directory, this
is already baked in to File::Temp which we are using.
    
Thanks @ehuelsmann for the suggestion.

Also there's no need to strip the trailing slash from the tempdir parameter
before passing it to File::Temp - so don't bother. One less line of code :)
