### PR TITLE
Use parameters if defined (rather than if true)

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -234,9 +234,9 @@ sub connect {
     my $connect = 'dbname="' . $self->dbname . '"';
 
     $connect .= ';host=' . $self->host
-        if $self->host;
+        if defined $self->host;
     $connect .= ';port=' . $self->port
-        if $self->port;
+        if defined $self->port;
     my $dbh =  DBI->connect('dbi:Pg:' . $connect,
                             $self->username, $self->password,
                             $options)
@@ -300,11 +300,11 @@ sub create {
     local $ENV{PGPASSWORD} = $self->password if $self->password;
 
     my @command = ('createdb');
-    $self->username and push(@command, '-U', $self->username);
-    $args{copy_of}  and push(@command, '-T', $args{copy_of});
-    $self->host     and push(@command, '-h', $self->host);
-    $self->port     and push(@command, '-p', $self->port);
-    $self->dbname   and push(@command, $self->dbname);
+    defined $self->username and push(@command, '-U', $self->username);
+    defined $args{copy_of}  and push(@command, '-T', $args{copy_of});
+    defined $self->host     and push(@command, '-h', $self->host);
+    defined $self->port     and push(@command, '-p', $self->port);
+    defined $self->dbname   and push(@command, $self->dbname);
 
     return $self->_run_command(command => [@command]);
 }
@@ -354,10 +354,10 @@ sub run_file {
 
     # Build command
     my @command = ('psql', '-f', $args{file});
-    $self->username and push(@command, "-U", $self->username);
-    $self->host     and push(@command, "-h", $self->host);
-    $self->port     and push(@command, "-p", $self->port);
-    $self->dbname   and push(@command, $self->dbname);
+    defined $self->username and push(@command, "-U", $self->username);
+    defined $self->host     and push(@command, "-h", $self->host);
+    defined $self->port     and push(@command, "-p", $self->port);
+    defined $self->dbname   and push(@command, $self->dbname);
 
     my $result = $self->_run_command(
         command    => [@command],
@@ -411,11 +411,11 @@ sub backup {
     my $output_fh = $self->_open_temp_filehandle(%args);
 
     my @command = ('pg_dump', '--verbose');
-    $self->username and push(@command, "-U", $self->username);
-    $self->host     and push(@command, "-h", $self->host);
-    $self->port     and push(@command, "-p", $self->port);
-    defined $args{format} and push(@command, "-F$args{format}");
-    $self->dbname   and push(@command, $self->dbname);
+    defined $self->username and push(@command, "-U", $self->username);
+    defined $self->host     and push(@command, "-h", $self->host);
+    defined $self->port     and push(@command, "-p", $self->port);
+    defined $args{format}   and push(@command, "-F$args{format}");
+    defined $self->dbname   and push(@command, $self->dbname);
 
     $self->_run_command_to_file(
         $output_fh,
@@ -464,9 +464,9 @@ sub backup_globals {
     my $output_fh = $self->_open_temp_filehandle(%args);
 
     my @command = ('pg_dumpall', '-g');
-    $self->username and push(@command, '-U', $self->username);
-    $self->host     and push(@command, '-h', $self->host);
-    $self->port     and push(@command, '-p', $self->port);
+    defined $self->username and push(@command, '-U', $self->username);
+    defined $self->host     and push(@command, '-h', $self->host);
+    defined $self->port     and push(@command, '-p', $self->port);
 
     $self->_run_command_to_file(
         $output_fh,
@@ -518,11 +518,11 @@ sub restore {
 
     # Build command options
     my @command = ('pg_restore', '--verbose');
-    $self->dbname   and push(@command, "-d", $self->dbname);
-    $self->username and push(@command, "-U", $self->username);
-    $self->host     and push(@command, "-h", $self->host);
-    $self->port     and push(@command, "-p", $self->port);
-    defined $args{format} and push(@command, "-F$args{format}");
+    defined $self->dbname   and push(@command, "-d", $self->dbname);
+    defined $self->username and push(@command, "-U", $self->username);
+    defined $self->host     and push(@command, "-h", $self->host);
+    defined $self->port     and push(@command, "-p", $self->port);
+    defined $args{format}   and push(@command, "-F$args{format}");
     push(@command, $args{file});
 
     return $self->_run_command(command => [@command]);
@@ -543,9 +543,9 @@ sub drop {
     local $ENV{PGPASSWORD} = $self->password if $self->password;
 
     my @command = ('dropdb');
-    $self->username and push(@command, '-U', $self->username);
-    $self->host     and push(@command, '-h', $self->host);
-    $self->port     and push(@command, '-p', $self->port);
+    defined $self->username and push(@command, '-U', $self->username);
+    defined $self->host     and push(@command, '-h', $self->host);
+    defined $self->port     and push(@command, '-p', $self->port);
     push(@command, $self->dbname);
 
     return $self->_run_command(command => [@command]);


### PR DESCRIPTION
Previously method parameters were effective only if they evaluated
to true. Mostly this was OK, but there are some edge cases where a
valid defined parameter evaluates to false.

Better to check if a parameter is defined - and use it if so.