### PR TITLE
Remove --verbose argument form pg_dump call in backup

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -410,7 +410,7 @@ sub backup {
     local $ENV{PGPASSWORD} = $self->password if defined $self->password;
     my $output_fh = $self->_open_temp_filehandle(%args);
 
-    my @command = ('pg_dump', '--verbose');
+    my @command = ('pg_dump');
     $self->username and push(@command, "-U", $self->username);
     $self->host     and push(@command, "-h", $self->host);
     $self->port     and push(@command, "-p", $self->port);


### PR DESCRIPTION
Argument was left over from development work tests. It causes
additional diagnostic data to be included in the resulting backup
file, which we do not want or require.

pg_dump is now executed without the --verbose switch.