### PR TITLE
Set newly created output file permissions to 0600

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -6,7 +6,6 @@ use warnings FATAL => 'all';
 
 use Carp;
 use DBI;
-use File::stat;
 use File::Temp;
 use IO::File;
 use Capture::Tiny 'capture';

--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -149,7 +149,7 @@ sub _run_command_to_file {
 }
 
 
-sub _open_temp_filehandle {
+sub _open_output_filehandle {
     my ($self, %args) = @_;
 
     # If caller has supplied a file path, use that
@@ -425,7 +425,7 @@ sub backup {
     $self->{stdout} = undef;
 
     local $ENV{PGPASSWORD} = $self->password if defined $self->password;
-    my $output_fh = $self->_open_temp_filehandle(%args);
+    my $output_fh = $self->_open_output_filehandle(%args);
 
     my @command = ('pg_dump');
     defined $self->username and push(@command, '-U', $self->username);
@@ -478,7 +478,7 @@ sub backup_globals {
     $self->{stdout} = undef;
 
     local $ENV{PGPASSWORD} = $self->password if defined $self->password;
-    my $output_fh = $self->_open_temp_filehandle(%args);
+    my $output_fh = $self->_open_output_filehandle(%args);
 
     my @command = ('pg_dumpall', '-g');
     defined $self->username and push(@command, '-U', $self->username);

--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -417,8 +417,11 @@ The specified format, for example c for custom.  Defaults to plain text.
 
 =item file
 
-Full path of the file to which the backup will be written. If not
-specified, a file will be created using File::Temp.
+Full path of the file to which the backup will be written. If the file
+does not exist, one will be created with umask 0600. If the file exists,
+it will be overwritten, but its permissions will not be changed.
+
+If undefined, a file will be created using File::Temp having umask 0600.
 
 =item tempdir
 
@@ -470,8 +473,11 @@ Accepted parameters:
 
 =item file
 
-Full path of the file to which the backup will be written. If not
-specified, a file will be created using File::Temp.
+Full path of the file to which the backup will be written. If the file
+does not exist, one will be created with umask 0600. If the file exists,
+it will be overwritten, but its permissions will not be changed.
+
+If undefined, a file will be created using File::Temp having umask 0600.
 
 =item tempdir
 

--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -157,16 +157,13 @@ sub _open_output_filehandle {
     # If caller has supplied a file path, use that
     # rather than generating our own temp file.
     if(defined $args{file}) {
-
-        # If file already exists, make sure it has 0600 permissions
-        # so it isn't executable and only user can read or write.
-        if(my $stat = stat($args{file})) {
-            $stat->mode != 0600 and chmod 0600, $args{file}
-                or croak "faied to set 0600 permissions on $args{file} $!";
-        }
-
-        # capture requires that the file be seekable
-        # use sysopen so we can set permissions at time of creation
+        # If file already exists, we don't alter its permissions,
+        # but new files are created with a mask of 0600 so they are
+        # only readable and writeable by the user that creates them.
+        #
+        # capture requires that the file be seekable.
+        #
+        # Use sysopen so we can set permissions at time of creation.
         sysopen(my $fh, $args{file}, O_RDWR|O_CREAT, 0600)
             or croak "couldn't open file $args{file} for writing $!";
 

--- a/t/01.1-dbtests.t
+++ b/t/01.1-dbtests.t
@@ -7,7 +7,7 @@ use PGObject::Util::DBAdmin;
 use File::Temp;
 
 plan skip_all => 'DB_TESTING not set' unless $ENV{DB_TESTING};
-plan tests => 78;
+plan tests => 70;
 
 # Constructor
 
@@ -23,39 +23,14 @@ ok($db = PGObject::Util::DBAdmin->new(
 ), 'Created db admin object');
 
 # Drop db if exists
-
 eval { $db->drop };
-
-# Test backup_globals to auto-generated temp file
-my $backup_file;
-ok($backup_file = $db->backup_globals(
-    tempdir => 't/var/',
-), 'can backup globals');
-ok(-f $backup_file, 'backup_globals output file exists');
-ok($backup_file =~ m|^t/var/|, 'backup file respects tempdir parameter');
-cmp_ok(-s $backup_file, '>', 0, 'backup_globals output file has size > 0');
-unlink $backup_file;
-
-# Test backup_globals to specified file
-my $output_file = File::Temp->new->filename;
-ok($backup_file = $db->backup_globals(
-    file => $output_file,
-), 'can backup globals to specified file');
-ok(-f $backup_file, 'specified backup_globals output file exists');
-ok($backup_file =~ m/^$output_file$/, 'backup_globals respects file parameter');
-cmp_ok(-s $backup_file, '>', 0, 'specified backup_globals output file has size > 0');
-unlink $output_file;
-
 
 # List dbs
 my @dblist;
-
 ok(@dblist = $db->list_dbs, 'Got a db list');
-
 ok (!grep {$_ eq 'pgobject_test_db'} @dblist, 'DB list does not contain pgobject_test_db');
 
 # Create db
-
 $db->create;
 
 ok($db->server_version, 'Got a server version');

--- a/t/01.2-backup_globals.t
+++ b/t/01.2-backup_globals.t
@@ -1,0 +1,77 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::Exception;
+use PGObject::Util::DBAdmin;
+use File::Temp;
+
+plan skip_all => 'DB_TESTING not set' unless $ENV{DB_TESTING};
+plan tests => 21;
+
+# Constructor
+
+my $dbh;
+my $db;
+my $temp;
+my $backup_file;
+
+ok($db = PGObject::Util::DBAdmin->new(
+     username => 'postgres',
+     password => undef,
+     dbname   => 'pgobject_test_db',
+     host     => 'localhost',
+     port     => '5432'
+), 'Created db admin object');
+
+# Drop db if exists
+eval { $db->drop };
+
+
+# Test backup_globals to auto-generated temp file
+ok($backup_file = $db->backup_globals(
+    tempdir => 't/var/',
+), 'backup_globals outputs to auto-generated file');
+ok(-f $backup_file, 'backup_globals output to auto-generated file exists');
+ok($backup_file =~ m|^t/var/|, 'backup_globals output to auto-generated file respects tempdir parameter');
+cmp_ok(-s $backup_file, '>', 0, 'backup_globals output to auto-generated file has size > 0');
+is((stat($backup_file))[2] & 07777, 0600, 'backup_globals output to auto-generated file has permissions 0600');
+unlink $backup_file;
+
+
+# Test backup_globals to not-existing specified file
+$temp = File::Temp->new->filename;
+ok(!-f $temp, 'backup_globals non-existent specified file does not exist');
+ok($backup_file = $db->backup_globals(
+    file => $temp,
+), 'backup_globals outputs to non-existent specified file');
+ok(-f $backup_file, 'backup_globals output to non-existent specified file exists');
+ok($temp =~ m/^$backup_file$/, 'backup_globals output to non-existent specified file respects file parameter');
+cmp_ok(-s $backup_file, '>', 0, 'backup_globals output to non-existent specified file has size > 0');
+is((stat($backup_file))[2] & 07777, 0600, 'backup_globals output to non-existent specified file has permissions 0600');
+unlink $backup_file;
+
+# Test backup_globals to overwrite existing specified file with 'wrong' permssions
+# Makes sure that file is written and permissions are unchanged
+$temp = File::Temp->new;
+chmod 0777, $temp->filename; # Give it wrong permissions
+is((stat($temp->filename))[2] & 07777, 0777, 'specified backup_globals output file created with permissions 0777');
+ok($backup_file = $db->backup_globals(
+    file => $temp->filename,
+), 'backup_globals outputs to existing specified file with permissions 0777');
+ok($temp->filename =~ m/^$backup_file$/, 'backup_globals output to existing specified file respects file parameter');
+cmp_ok(-s $backup_file, '>', 0, 'backup_globals output to existing specified file with permissions 0777 has size > 0');
+is((stat($backup_file))[2] & 07777, 0777, 'backup_globals output to existing specified file retains permissions 0777');
+undef $temp;
+
+# Test backup_globals to overwrite existing specified file with 'right' permssions
+# Make sure file is written and 'correct' 0600 permissions are retained
+$temp = File::Temp->new;
+is((stat($temp->filename))[2] & 07777, 0600, 'specified backup_globals output file created with permissions 0600');
+ok($backup_file = $db->backup_globals(
+    file => $temp->filename,
+), 'backup globals outut to existing specified file with permissions 0600');
+cmp_ok(-s $backup_file, '>', 0, 'backup_globals to existing specified file with permissions 0600 has size > 0');
+is((stat($backup_file))[2] & 07777, 0600, 'backup_globals output to existing specified file retains permissions 0600');
+undef $temp;
+

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -55,7 +55,6 @@ verbose =%s %p %f   %l\n
 [TestingAndDebugging::RequireUseWarnings]
 [ValuesAndExpressions::ProhibitCommaSeparatedStatements]
 [ValuesAndExpressions::ProhibitInterpolationOfLiterals]
-[ValuesAndExpressions::ProhibitLeadingZeros]
 [ValuesAndExpressions::ProhibitMagicNumbers]
     allowed_values = -1 0 1 2 100
 [ValuesAndExpressions::ProhibitMismatchedOperators]
@@ -66,3 +65,10 @@ verbose =%s %p %f   %l\n
 [Variables::RequireInitializationForLocalVars]
 [Variables::RequireLexicalLoopIterators]
 [Variables::RequireLocalizedPunctuationVars]
+
+# Not applied
+#
+# Because we use octal values to refer to file permissions
+# Wrapping each of these in an oct(..) as Perl::Critic suggests
+# harms readability.
+# [ValuesAndExpressions::ProhibitLeadingZeros]


### PR DESCRIPTION
Following suggestion from @ehuelsmann to better protect backup files, ensure newly-created files are initialised with 0600 permissions, so they are readable and writeable only by the user that creates them.

I have taken the view that when explicitly asked to overwrite an existing file, it's permissions should not be altered, so this only affects newly created files.

Tests have been added for this.