### PR TITLE
Don't parse stderr for errors, rely on exit code check

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -120,10 +120,6 @@ sub _run_command {
         croak 'error running command';
     }
 
-    for my $err (split /\n/, $self->{stderr}) {
-        croak $err if $err =~ /(ERROR|FATAL)/;
-    }
-
     return 1;
 }
 
@@ -145,15 +141,6 @@ sub _run_command_to_file {
         $output_filename,
         'error running command'
     );
-
-    for my $err (split /\n/, $self->{stderr}) {
-        if($err =~ /(ERROR|FATAL)/) {
-            $self->_unlink_file_and_croak(
-                $output_filename,
-                $err
-            );
-        }
-    }
 
     return 1;
 }
@@ -396,7 +383,7 @@ sub run_file {
     local $ENV{PGPASSWORD} = $self->password if defined $self->password;
 
     # Build command
-    my @command = ('psql', '-f', $args{file});
+    my @command = ('psql', '--set=ON_ERROR_STOP=on', '-f', $args{file});
     defined $self->username and push(@command, '-U', $self->username);
     defined $self->host     and push(@command, '-h', $self->host);
     defined $self->port     and push(@command, '-p', $self->port);
@@ -568,7 +555,7 @@ sub restore {
     local $ENV{PGPASSWORD} = $self->password if defined $self->password;
 
     # Build command options
-    my @command = ('pg_restore', '--verbose');
+    my @command = ('pg_restore', '--verbose', '--exit-on-error');
     defined $self->dbname   and push(@command, '-d', $self->dbname);
     defined $self->username and push(@command, '-U', $self->username);
     defined $self->host     and push(@command, '-h', $self->host);


### PR DESCRIPTION
Following the execution of external commands, such as pg_dump,
pg_dumpall, psql, dropdb, createdb, stderr output is no longer
parsed for ERROR or FATAL messages. Instead we rely on checking
the exit status of those commands.

The change is made because stderr could legitimately contain the
characters 'ERROR' or 'FATAL' as part of successful
execution of the external commands, leading to false failures.

When the checks of stderr was first added, they were the only test for
error during execution (though they didn't actually trap all error
conditions). Now that the process' exit code is checked, it is not
necessary to parse stderr.

* `psql` is now run with the `--set=ON_ERROR_STOP=on` switch.
* `pg_restore` is now run with the `--exit-on-error` switch.