### PR TITLE
Make file tests depend on DB_TESTING

### DIFF
--- a/t/03-file_errors.t
+++ b/t/03-file_errors.t
@@ -5,11 +5,11 @@ use Test::More;
 use PGObject::Util::DBAdmin;
 use Test::Exception;
 
+plan skip_all => 'DB_TESTING not set' unless $ENV{DB_TESTING};
 plan tests => 8;
 
 my $output_file = File::Temp->new->filename;
 
-# These tests do not require a working database connection
 my $db = PGObject::Util::DBAdmin->new(
    username => 'postgres'        ,
    host     => 'localhost'       ,


### PR DESCRIPTION
Renamed the old `03-shellexceptions tests.t` to `03-file_errors.t`.

We no longer involve the shell in running external commands (since
0.120.0) so the previous test name was misleading.

Now that we no longer use the shell, the response to file errors
comes from the underlying postgreSQL utility (such as pg_dump). We
need these to be available for the tests to run, so the test is
now dependent on DB_TESTING environment variable being set.