### PR TITLE
Add `compress` parameter to backup() method

### DIFF
--- a/lib/PGObject/Util/DBAdmin.pm
+++ b/lib/PGObject/Util/DBAdmin.pm
@@ -412,6 +412,11 @@ If undefined, a file will be created using File::Temp having umask 0600.
 The directory in which to write the backup file. Optional parameter.  Uses
 File::Temp default if not defined.  Ignored if file paramter is given.
 
+=item compress
+
+Optional parameter. Specifies the compression level to use and is passed to
+the underlying pg_dump command. Default is no compression.
+
 =back
 
 =cut
@@ -428,6 +433,7 @@ sub backup {
     defined $self->username and push(@command, '-U', $self->username);
     defined $self->host     and push(@command, '-h', $self->host);
     defined $self->port     and push(@command, '-p', $self->port);
+    defined $args{compress} and push(@command, '-Z', $args{compress});
     defined $args{format}   and push(@command, "-F$args{format}");
     defined $self->dbname   and push(@command, $self->dbname);
 

--- a/t/01.1-dbtests.t
+++ b/t/01.1-dbtests.t
@@ -7,7 +7,7 @@ use PGObject::Util::DBAdmin;
 use File::Temp;
 
 plan skip_all => 'DB_TESTING not set' unless $ENV{DB_TESTING};
-plan tests => 70;
+plan tests => 75;
 
 # Constructor
 
@@ -113,3 +113,16 @@ foreach my $format ((undef, 'p', 'c')) {
     $dbh->disconnect;
     unlink $backup;
 }
+
+# Test backing up to compressed auto-generated temp file
+my $backup;
+my $fh;
+ok($backup = $db->backup(
+    tempdir => 't/var/',
+    compress => 9,
+), "Made backup, compressed");
+ok(-f $backup, "backup, compressed output file exists");
+cmp_ok(-s $backup, '>', 0, "backup, compressed output file has size > 0");
+ok(open ($fh, '<', $backup), "backup, compressed output file opened successfully");
+like(<$fh>, qr/^\x1F\x8B/, 'backup, compressed output file is gzip format');
+unlink $backup;


### PR DESCRIPTION
backup() method now accepts an optional compress parameter, which
is passed to pg_dump. Test added, which checks first two bytes of file
for gzip signature on a compressed plain-text backup.

Added as per @sbts request on lsmb mailing list: https://matrix.to/#/!qyoLumPqusaXqFJNyK:matrix.org/$15237838752036770IgKus:matrix.org