### PR TITLE
Cleanse the environment before invoking external programs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Revision history for PGObject-Util-DBAdmin
 
 
+0.131.0 2019-07-06
+        Sanitize the environment before shelling out to external programs,
+        because (a) that's the secure thing to do and (b) it breaks the
+        called programs if the environment contains debugging settings
+
 0.130.1 2018-06-05
         Correct typos in documentation
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use 5.008;
+use 5.010;
 use strict;
 use warnings FATAL => 'all';
 use ExtUtils::MakeMaker;


### PR DESCRIPTION
LedgerSMB's coverage testing environment variables trigger coverage testing of the (perl-based) PostgreSQL tools (createdb, dropdb, psql, ...). This is (obviously) highly undesirable and demonstrates that we should cleanse the environment before calling external programs.