### PR TITLE
* Factor out a 'verify_helpers' function

### DIFF
--- a/t/01.3-verify-helpers.t
+++ b/t/01.3-verify-helpers.t
@@ -1,0 +1,33 @@
+use warnings;
+use strict;
+
+use Test::More;
+use PGObject::Util::DBAdmin;
+
+plan tests => 3;
+
+
+is_deeply( PGObject::Util::DBAdmin->verify_helpers,
+           {
+               map { $_ => 1 }
+               keys %PGObject::Util::DBAdmin::helper_paths
+           },
+           'Without arguments, test all helpers');
+
+is_deeply( PGObject::Util::DBAdmin->verify_helpers(
+               operations => [ keys %PGObject::Util::DBAdmin::helpers ]
+           ),
+           {
+               map { $_ => 1 }
+               keys %PGObject::Util::DBAdmin::helper_paths
+           },
+           'With the "operations" argument, test the associated helpers');
+
+is_deeply( PGObject::Util::DBAdmin->verify_helpers(
+               helpers => [ keys %PGObject::Util::DBAdmin::helper_paths ]
+           ),
+           {
+               map { $_ => 1 }
+               keys %PGObject::Util::DBAdmin::helper_paths
+           },
+           'With the "helpers" argument, test the associated helpers');


### PR DESCRIPTION
This function requests the module to assert whether or
not it is able to run one or several of its required
external helper applications.  By offering this API,
there is no need to duplicate or approximate its behaviour
in any callers.